### PR TITLE
Add profiles to BitBot

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -92,8 +92,6 @@ client.once('ready', async () => {
 });
 
 client.on('interactionCreate', async (interaction) => {
-	if (!interaction.isCommand() && !interaction.isButton()) return;
-
 	if (interaction.isButton()) {
 		let args = interaction.customId.split(' ');
 		let id = args.shift();
@@ -111,6 +109,8 @@ client.on('interactionCreate', async (interaction) => {
 			}
 		}
 	}
+
+	if (!interaction.isCommand() && !interaction.isContextMenu()) return;
 
 	const command = client.commands.get(interaction.commandName);
 

--- a/commands/View Profile.js
+++ b/commands/View Profile.js
@@ -1,0 +1,13 @@
+const profile = require('../lib/profiles');
+
+module.exports = {
+	data: {
+		name: 'View Profile',
+		type: 2
+	},
+	ephemeral: true,
+	context: true,
+	async execute(interaction) {
+		profile.displayProfile(interaction);
+	}
+};

--- a/commands/profile.js
+++ b/commands/profile.js
@@ -1,0 +1,56 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const Discord = require('discord.js');
+const ldap = require('../lib/ldap');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('profile')
+		.setDescription(
+			"View a user's UTDesign Makerspace profile if they have linked their Discord account."
+		)
+		.addUserOption((option) =>
+			option
+				.setName('user')
+				.setDescription('The user to view the profile of')
+		),
+	ephemeral: true,
+	execute: async (interaction) => {
+		// Get the member who we want to view the profile of
+		// If no member specified, assume the user is viewing their own profile
+		let member = interaction.member;
+		const memberOption = interaction.options.getUser('user');
+		if (memberOption) {
+			member = interaction.guild.members.cache.get(memberOption.id);
+		}
+
+		// Grab the LDAP member
+		const ldapMember = await ldap.getUserByDiscord(member.id);
+
+		let profileEmbed = new Discord.MessageEmbed()
+			.setColor('#c1393d')
+			.setAuthor(
+				member.displayName,
+				member.displayAvatarURL({ dynamic: true })
+			);
+		// If there doesn't exist a linked account, add it to the embed
+		if (!ldapMember) {
+			profileEmbed
+				.setTitle('No linked account')
+				.setDescription(
+					'This user has not linked their Discord account to their UTDesign Makerspace account. For more information, use /link.'
+				);
+		} else {
+			// Otherwise, assuming there is a linked account...
+			profileEmbed
+				.setTitle(`${ldapMember.givenName} ${ldapMember.sn}`)
+				.setDescription('<:MakerspaceOfficer:940693728308379669>')
+				.addField('Bits', '1000', true)
+				.addField('Total Bits', '100000', true)
+				.addField('Membership Status', 'Officer', true)
+				.addField('Training', '3D Printing\nLaser Cutting', false)
+				.addField('Awards', 'Makerspace Game of the Year 2022', false);
+		}
+
+		interaction.editReply({ embeds: [profileEmbed] });
+	}
+};

--- a/commands/profile.js
+++ b/commands/profile.js
@@ -1,7 +1,5 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const Discord = require('discord.js');
-const ldap = require('../lib/ldap');
-const constants = require('../lib/constants');
+const profiles = require('../lib/profiles');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -16,96 +14,6 @@ module.exports = {
 		),
 	ephemeral: true,
 	execute: async (interaction) => {
-		// Get the member who we want to view the profile of
-		// If no member specified, assume the user is viewing their own profile
-		let member = interaction.member;
-		const memberOption = interaction.options.getUser('user');
-		if (memberOption) {
-			member = interaction.guild.members.cache.get(memberOption.id);
-		}
-
-		// Grab the LDAP member
-		const ldapMember = await ldap.getUserByDiscord(member.id);
-
-		let profileEmbed = new Discord.MessageEmbed()
-			.setColor('#c1393d')
-			.setAuthor(
-				member.displayName,
-				member.displayAvatarURL({ dynamic: true })
-			);
-		// If there doesn't exist a linked account, add it to the embed
-		if (!ldapMember) {
-			profileEmbed
-				.setTitle('No linked account')
-				.setDescription(
-					'This user has not linked their Discord account to their UTDesign Makerspace account. For more information, use /link.'
-				);
-		} else {
-			// Otherwise, assuming there is a linked account...
-
-			// Grab their groups
-			const groups = await ldap.getGroupsByUsername(ldapMember.cn);
-
-			// Create the base embed
-			profileEmbed
-				.setTitle(`${ldapMember.givenName} ${ldapMember.sn}`)
-				.addField('Bits', 'WIP', true)
-				.addField('Total Bits', 'WIP', true);
-
-			// Add membership status
-			if (member.roles.cache.some((role) => role.name == 'Staff'))
-				profileEmbed.addField('Membership Status', 'Staff', true);
-			else if (member.roles.cache.some((role) => role.name == 'Officer'))
-				profileEmbed.addField('Membership Status', 'Officer', true);
-			else if (
-				member.roles.cache.some((role) =>
-					role.name.includes('Committee')
-				)
-			)
-				profileEmbed.addField(
-					'Membership Status',
-					'Committee Member',
-					true
-				);
-			else profileEmbed.addField('Membership Status', 'Member', true);
-
-			// Add trainings
-			let trainings = '';
-			if (groups.some((group) => group.cn === 'trained-3dprinting'))
-				trainings += '3D Printing\n';
-			if (groups.some((group) => group.cn === 'trained-lasercutting'))
-				trainings += 'Laser Cutting\n';
-			if (trainings) profileEmbed.addField('Training', trainings, false);
-
-			// Add awards
-			// NEEDS TO BE ADDED, WAITING ON LDAP CHANGES
-			// profileEmbed.addField(
-			// 	'Awards',
-			// 	'Makerspace Game of the Year 2022',
-			// 	false
-			// );
-
-			// Add badges
-			// AWARD AND DONOR NEED TO BE ADDED
-			let badges = '';
-			if (
-				member.roles.cache.some(
-					(role) => role.name == 'Staff' || role.name == 'Officer'
-				)
-			)
-				badges += '<:MakerspaceOfficer:940693728308379669> ';
-			else if (
-				member.roles.cache.some((role) =>
-					role.name.includes('Committee')
-				)
-			)
-				badges += '<:CommitteeMember:941081405507633162> ';
-			if (groups.some((group) => group.cn === 'arcadedev'))
-				badges += '<:ArcadeGameDeveloper:941081405297942649> ';
-			if (constants.contributors.includes(member.id))
-				badges += '<:BitBotContributor:941081405650251827> ';
-			profileEmbed.setDescription(badges);
-		}
-		interaction.editReply({ embeds: [profileEmbed] });
+		profiles.displayProfile(interaction);
 	}
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,8 @@ const Discord = require('discord.js');
 dotenv.config();
 
 module.exports = {
+	// If you have contributed to our project on GitHub, add your Discord user ID here
+	contributors: ['164134588275228674', '201049866967711744'],
 	printers: {
 		blue: {
 			name: 'Blue', // Should be the color of the printer

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -33,5 +33,17 @@ module.exports = {
 			}
 		);
 		return users[0];
+	},
+	getGroupsByUsername: async function (username, attributes = ['cn']) {
+		await client.bind(process.env.LDAP_BIND_DN, process.env.LDAP_BIND_PASS);
+		const { entries: groups } = await client.searchReturnAll(
+			process.env.LDAP_GROUPS_BASE,
+			{
+				filter: `(&(objectClass=posixGroup)(memberUid=${username}))`,
+				scope: 'sub',
+				attributes
+			}
+		);
+		return groups;
 	}
 };

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -65,7 +65,7 @@ module.exports = {
 			if (trainings) profileEmbed.addField('Training', trainings, false);
 
 			// Add awards
-			// NEEDS TO BE ADDED, WAITING ON LDAP CHANGES
+			// NEEDS TO BE ADDED, WAITING ON LDAP CHANGE TO ADD AWARDS STRING
 			// profileEmbed.addField(
 			// 	'Awards',
 			// 	'Makerspace Game of the Year 2022',
@@ -73,7 +73,7 @@ module.exports = {
 			// );
 
 			// Add badges
-			// AWARD AND DONOR NEED TO BE ADDED
+			// NEEDS MORE FEATURES, WAITING ON LDAP CHANGE TO ADD AWARDS STRING AND DONATION AMOUNT
 			let badges = '';
 			if (
 				member.roles.cache.some(

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -1,0 +1,98 @@
+const Discord = require('discord.js');
+const ldap = require('../lib/ldap');
+const constants = require('../lib/constants');
+
+module.exports = {
+	// NOTE: All methods assume message will NOT be ephemeral. You will need to add that yourself.
+	async displayProfile(interaction) {
+		// Get the member who we want to view the profile of
+		// If no member specified, assume the user is viewing their own profile
+		let user = interaction.options.getUser('user');
+		if (!user) user = interaction.user;
+		const member = interaction.guild.members.cache.get(user.id);
+
+		// Grab the LDAP member
+		const ldapMember = await ldap.getUserByDiscord(member.id);
+
+		let profileEmbed = new Discord.MessageEmbed()
+			.setColor('#c1393d')
+			.setAuthor({
+				name: member.displayName,
+				iconURL: member.displayAvatarURL({ dynamic: true })
+			});
+		// If there doesn't exist a linked account, add it to the embed
+		if (!ldapMember) {
+			profileEmbed
+				.setTitle('No linked account')
+				.setDescription(
+					'This user has not linked their Discord account to their UTDesign Makerspace account. For more information, use /link.'
+				);
+		} else {
+			// Otherwise, assuming there is a linked account...
+
+			// Grab their groups
+			const groups = await ldap.getGroupsByUsername(ldapMember.cn);
+
+			// Create the base embed
+			profileEmbed
+				.setTitle(`${ldapMember.givenName} ${ldapMember.sn}`)
+				.addField('Bits', 'WIP', true)
+				.addField('Total Bits', 'WIP', true);
+
+			// Add membership status
+			if (member.roles.cache.some((role) => role.name == 'Staff'))
+				profileEmbed.addField('Membership Status', 'Staff', true);
+			else if (member.roles.cache.some((role) => role.name == 'Officer'))
+				profileEmbed.addField('Membership Status', 'Officer', true);
+			else if (
+				member.roles.cache.some((role) =>
+					role.name.includes('Committee')
+				)
+			)
+				profileEmbed.addField(
+					'Membership Status',
+					'Committee Member',
+					true
+				);
+			else profileEmbed.addField('Membership Status', 'Member', true);
+
+			// Add trainings
+			let trainings = '';
+			if (groups.some((group) => group.cn === 'trained-3dprinting'))
+				trainings += '3D Printing\n';
+			if (groups.some((group) => group.cn === 'trained-lasercutting'))
+				trainings += 'Laser Cutting\n';
+			if (trainings) profileEmbed.addField('Training', trainings, false);
+
+			// Add awards
+			// NEEDS TO BE ADDED, WAITING ON LDAP CHANGES
+			// profileEmbed.addField(
+			// 	'Awards',
+			// 	'Makerspace Game of the Year 2022',
+			// 	false
+			// );
+
+			// Add badges
+			// AWARD AND DONOR NEED TO BE ADDED
+			let badges = '';
+			if (
+				member.roles.cache.some(
+					(role) => role.name == 'Staff' || role.name == 'Officer'
+				)
+			)
+				badges += '<:MakerspaceOfficer:940693728308379669> ';
+			else if (
+				member.roles.cache.some((role) =>
+					role.name.includes('Committee')
+				)
+			)
+				badges += '<:CommitteeMember:941081405507633162> ';
+			if (groups.some((group) => group.cn === 'arcadedev'))
+				badges += '<:ArcadeGameDeveloper:941081405297942649> ';
+			if (constants.contributors.includes(member.id))
+				badges += '<:BitBotContributor:941081405650251827> ';
+			profileEmbed.setDescription(badges);
+		}
+		interaction.editReply({ embeds: [profileEmbed] });
+	}
+};


### PR DESCRIPTION
This feature will allow members to view a profile if they've connected their Discord and UTDesign Makerspace accounts.

Currently supports...
- Currency placeholder
- Officer, staff, committee member, and member status
- Training completed
- Officer, committee member, arcade game developer, and BitBot contributor badges

Waiting to add the following...
- Awards badge/field (waiting on LDAP string)
- Donor badge/amount (waiting on LDAP number)